### PR TITLE
Fix for larger itterations

### DIFF
--- a/Assignment 8 - Fractal Patterns using Koch Curves.c
+++ b/Assignment 8 - Fractal Patterns using Koch Curves.c
@@ -20,6 +20,7 @@ void kochCurve(GLfloat dir,GLfloat len,GLint iter)
 	else
 	{
 		iter -= 1;	
+		len = len / 3;			//Keeps the shape size same so that it doesn't scale up for larger iterations
 		kochCurve(dir, len, iter);	//draw the four parts of the side _/\_
 		dir += 60.0;
 		kochCurve(dir, len, iter);


### PR DESCRIPTION
Keeps the shape size same so that it doesn't scale up for larger iterations. Otherwise length of each line remains the same. Whereas it actually should be 1/3rd of previous itteration's length.